### PR TITLE
Add new CORS allowed domains for Android App

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -79,6 +79,13 @@ def create_app(config_class=None):
                 "https://brewtracker-wheat.vercel.app",
             ),
             "https://*.vercel.app",  # Allow Vercel preview deployments
+            # Android app origins
+            "capacitor://localhost",  # Capacitor apps
+            "ionic://localhost",  # Ionic apps
+            "http://localhost",  # React Native/Expo local development
+            "https://localhost",  # HTTPS local development
+            "file://",  # File protocol for mobile apps
+            "about:blank",  # Initial app load state
         ]
     else:
         # Development CORS
@@ -90,6 +97,16 @@ def create_app(config_class=None):
             "http://localhost:8081",
             "http://127.0.0.1:8081",
             "http://192.168.0.10:8081",
+            # Mobile development origins
+            "capacitor://localhost",
+            "ionic://localhost",
+            "http://localhost",
+            "https://localhost",
+            "file://",
+            "about:blank",
+            # Flexible IP ranges for mobile development
+            "http://192.168.*:8081",
+            "http://10.*:8081",
         ]
 
     CORS(

--- a/backend/app.py
+++ b/backend/app.py
@@ -145,17 +145,6 @@ def create_app(config_class=None):
     add_security_headers(app)
     setup_error_handlers(app)
 
-    # Add request origin logging for development debugging
-    if flask_env == "development":
-
-        @app.before_request
-        def log_request_origin():
-            origin = request.headers.get("Origin", "No Origin Header")
-            user_agent = request.headers.get("User-Agent", "No User-Agent")
-            print(
-                f"[CORS DEBUG] Request from Origin: '{origin}' | User-Agent: {user_agent[:100]}..."
-            )
-
     # Add security monitoring middleware
     @app.before_request
     def before_request():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved CORS behavior: production now accepts Vercel subdomains, native app schemes, localhost variants, and optional null/file origins when enabled; development allows mobile/WebView schemes, APK/file origins, localhost, null, and local LAN IP ranges.
  * Environment-driven toggle for CORS credentials and clearer startup logs of allowed origins.

* **Bug Fixes**
  * Fewer cross-origin failures for mobile, local dev, and file-based clients via refined origin rules and credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->