### PR TITLE
Add DataVersion model and /version endpoints for styles, ingredients

### DIFF
--- a/backend/models/mongo_models.py
+++ b/backend/models/mongo_models.py
@@ -1118,3 +1118,18 @@ class DataVersion(Document):
             **update,
         )
         return version
+
+    @classmethod
+    def bump_and_adjust_count(cls, data_type, delta=0):
+        import uuid
+
+        now = datetime.now(UTC)
+        return cls.objects(data_type=data_type).modify(
+            upsert=True,
+            new=True,
+            inc__total_records=delta,
+            set__version=str(uuid.uuid4()),
+            set__last_modified=now,
+            set__last_count_update=now,
+            set_on_insert__data_type=data_type,
+        )

--- a/backend/routes/ingredients.py
+++ b/backend/routes/ingredients.py
@@ -101,8 +101,14 @@ def create_ingredient():
         DataVersion.update_version(
             "ingredients", total_records=Ingredient.objects().count()
         )
-    except Exception:
-        pass  # non-blocking
+    except Exception as e:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Failed to update ingredients DataVersion after create: %s",
+            e,
+            exc_info=True,
+        )
     return jsonify(ingredient.to_dict()), 201
 
 
@@ -125,8 +131,14 @@ def update_ingredient(ingredient_id):
     # Bump data version (non-blocking)
     try:
         DataVersion.update_version("ingredients")
-    except Exception:
-        pass
+    except Exception as e:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Failed to update ingredients DataVersion after update: %s",
+            e,
+            exc_info=True,
+        )
     return jsonify(ingredient.to_dict()), 200
 
 
@@ -144,8 +156,14 @@ def delete_ingredient(ingredient_id):
         DataVersion.update_version(
             "ingredients", total_records=Ingredient.objects().count()
         )
-    except Exception:
-        pass
+    except Exception as e:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Failed to update ingredients DataVersion after delete: %s",
+            e,
+            exc_info=True,
+        )
     return jsonify({"message": "Ingredient deleted successfully"}), 200
 
 

--- a/backend/routes/ingredients.py
+++ b/backend/routes/ingredients.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import get_jwt_identity, jwt_required
-from mongoengine.errors import OperationError
+from mongoengine.errors import MongoEngineException
 from pymongo.errors import PyMongoError
 
 from models.mongo_models import DataVersion, Ingredient, User
@@ -103,7 +103,7 @@ def create_ingredient():
         DataVersion.update_version(
             "ingredients", total_records=Ingredient.objects().count()
         )
-    except (OperationError, PyMongoError) as e:
+    except (MongoEngineException, PyMongoError) as e:
         import logging
 
         logging.getLogger(__name__).warning(
@@ -133,7 +133,7 @@ def update_ingredient(ingredient_id):
     # Bump data version (non-blocking)
     try:
         DataVersion.update_version("ingredients")
-    except (OperationError, PyMongoError) as e:
+    except (MongoEngineException, PyMongoError) as e:
         import logging
 
         logging.getLogger(__name__).warning(
@@ -158,7 +158,7 @@ def delete_ingredient(ingredient_id):
         DataVersion.update_version(
             "ingredients", total_records=Ingredient.objects().count()
         )
-    except (OperationError, PyMongoError) as e:
+    except (MongoEngineException, PyMongoError) as e:
         import logging
 
         logging.getLogger(__name__).warning(
@@ -225,7 +225,7 @@ def get_ingredients_version():
         resp = resp.make_conditional(request)
         return resp
 
-    except (OperationError, PyMongoError) as e:
+    except (MongoEngineException, PyMongoError) as e:
         import logging
 
         logger = logging.getLogger(__name__)

--- a/backend/tests/test_ingredients.py
+++ b/backend/tests/test_ingredients.py
@@ -315,8 +315,8 @@ class TestIngredientEndpoints:
         ingredient = sample_ingredients[-1]  # Irish Moss
         response = client.delete(f"/api/ingredients/{ingredient.id}", headers=headers)
 
-        assert response.status_code == 200
-        assert "deleted successfully" in response.json["message"]
+        assert response.status_code == 204  # "No Content" HTTP status
+        assert response.data == b""
 
         # Verify ingredient is deleted
         deleted_ingredient = Ingredient.objects(id=ingredient.id).first()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Centralized data-versioning for static collections with serialized metadata and cache-aware record counts.
  - New public GET /version endpoints for beer styles and ingredients returning version ID, last_modified (ISO), total_records, and data_type.
  - Endpoints support ETag/If-None-Match, Last-Modified, and public caching with configurable TTL.
  - Create/update/delete operations trigger version bumps and update cached counts (eager or non-blocking as appropriate).

- **Bug Fixes**
  - Consistent error handling: logs and returns 500 on version retrieval or update failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->